### PR TITLE
Plan: README execution protocol

### DIFF
--- a/cohort/plan/readme.md
+++ b/cohort/plan/readme.md
@@ -1,49 +1,124 @@
-# Plan README Playbook
+# Plan-README Execution Protocol
 
-These are the steps I follow whenever Adam tags a repository with the `plan-readme` topic. The goal: audit the repo’s current README coverage, understand open work, and stage a planning branch (`plan/<focus>`) with whatever documentation or task breakdown is needed next.
+When Adam tags a repo with the `plan-readme` topic, I go into "README planner" mode. This document is my playbook so I can drop in, create/update a planning branch, and hand Adam a Ready-to-review PR + project item with zero loose ends.
 
 ---
 
-## 1. Discover target repositories
-1. List every `gautada/*` repo that carries the topic:
+## 0. Prereqs
+- `gh` CLI authenticated with `GITHUB_PA_PLAN_TOKEN`.
+- Push access to all `gautada/*` repos (already granted).
+- URL for the **Eureka FARMS** project board (https://github.com/users/gautada/projects/2/views/3).
+
+---
+
+## 1. Discover active repos
+1. List every repo carrying the `plan-readme` topic:
    ```bash
-   gh repo list gautada --topic plan-readme --json name,sshUrl,description --limit 200
+   gh repo list gautada --topic plan-readme --json nameWithOwner,description,sshUrl --limit 200
    ```
-2. If nothing is returned, stop — there is no work.
-3. Otherwise, work through the repos one at a time (oldest untouched first if timestamps are available).
+2. If the command returns an empty array, stop — there is no work.
+3. Otherwise, process each repo in alphabetical order (oldest untouched first if timestamps available).
 
-## 2. Clone + hydrate the repo locally
-1. `git clone <repo>` (or `git fetch --all` if already present).
-2. `git remote -v` to confirm I have push rights.
-3. `git branch -r` to see every remote branch.
-4. `git fetch --prune` so local state mirrors GitHub.
+Document progress in `notes.md` inside each plan branch.
 
-## 3. Full-state review checklist
-For each repo (and each branch noted above):
+---
 
-| Area | Actions |
+## 2. Hydrate the repo
+For each repo identified above:
+1. Clone if needed: `git clone <repo-url>`.
+2. `cd <repo>` and `git fetch --all --prune`.
+3. Inspect remote branches: `git branch -r`.
+
+---
+
+## 3. Ensure `dev` baseline
+1. Check if `origin/dev` exists.
+2. If **yes**: `git checkout dev && git pull`.
+3. If **no**: create it from `main` (or default) and push:
+   ```bash
+   git checkout -b dev origin/main
+   git push -u origin dev
+   ```
+
+All plan work starts from the latest `dev` branch.
+
+---
+
+## 4. Create a planning branch
+1. Choose a slug that reflects the change, e.g. `plan/readme-refresh`, `plan/platform-docs`, etc.
+2. `git checkout -b plan/<slug> origin/dev`.
+3. Create `notes.md` (if missing) and capture:
+   - Repo state summary
+   - Branch inventory & stale items
+   - Issue audit takeaways
+   - README gaps + proposed fixes
+
+---
+
+## 5. Audit & update README
+Run this checklist for every README in the repo (root + major subdirs):
+
+| Section | Requirement |
 | --- | --- |
-| README + docs | Open every README, docs folder, and `/cohort/plan` assets. Capture gaps, outdated steps, or missing acceptance criteria. |
-| Branches | Scan active branches (`git branch -r`, `gh pr list`). Note any stale plan branches that should be closed or refreshed. |
-| Issues | `gh issue list --state all` to understand current backlog. Flag anything blocking README updates. |
-| Automations | Check workflows/scripts referenced by the README so instructions stay truthful. |
+| Overview | Explain purpose, owner, and current status. Keep the first paragraph under 80 words. |
+| Architecture | Link to diagrams or describe key services/components. |
+| Environments | Document dev/stage/prod URLs and login notes. |
+| Setup | Step-by-step bootstrap instructions (dependencies, env vars, local run commands). |
+| Operations | How to deploy, run tests, restart services, rotate secrets. |
+| Planning hooks | List open issues/epics relevant to this repo, plus link to the active plan branch. |
+| Contact | Point-of-contact (Adam/Nyx/blair) and escalation path. |
 
-Document findings as bullet notes in `notes.md` (or similar) inside the new plan branch.
-
-## 4. Create the planning branch
-1. Choose a concise slug, e.g. `plan/readme-refresh`, `plan/labs-docs`, etc.
-2. `git checkout -b plan/<slug>` from the latest default branch (usually `main`).
-3. Commit any planning artifacts (notes, updated README drafts, issue templates, etc.). Keep commits scoped to planning/documentation.
-4. Push with:
-   ```bash
-   git push -u origin plan/<slug>
-   ```
-
-## 5. Surface follow-ups
-1. Open/Update issues summarizing the README gaps and proposed fixes.
-2. Link the plan branch + issues back to Adam (Slack or GitHub comment) so Nyx knows work is ready.
-3. Remove the `plan-readme` topic once the plan is delivered (or ask Adam to do it).
+Rules:
+- Use tables or callouts when it improves scanability.
+- Assume Nyx is the reader: no fluff, no TODO placeholders.
+- Keep instructions repo-specific — no generic “TBD”.
+- If work spans multiple files (e.g., `/docs/README.md`), fix them in the same branch.
 
 ---
 
-**Success =** every `plan-readme` repo has an up-to-date planning branch, documented findings, and clear tasks queued for implementation.
+## 6. Git hygiene
+1. `git status` should show only intended README/docs/notes changes.
+2. Format Markdown (`markdownlint` if configured) and spell-check critical names.
+3. Commit message format: `chore: refresh README plan context` (tweak verb as needed).
+
+---
+
+## 7. Push & open PR
+1. `git push -u origin plan/<slug>`.
+2. Open a PR targeting `dev`:
+   ```bash
+   gh pr create \
+     --base dev \
+     --head plan/<slug> \
+     --title "Plan: <short summary>" \
+     --body "See notes in /cohort/plan for context." \
+     --assignee @gautada
+   ```
+3. Include checklist items in the PR body if multiple READMEs changed.
+
+---
+
+## 8. Project tracking
+For each PR:
+1. Open the **Eureka FARMS** project board.
+2. Create a new item under "Ready" with:
+   - **Title:** `Review README plan for <repo>`
+   - **Assignee:** Adam
+   - **Status:** Ready
+   - **Body:** Link to the PR + summary of what changed.
+
+---
+
+## 9. Hand-off
+1. DM Adam (or comment on the PR) with:
+   - Link to the PR
+   - Link to the project item
+   - One-paragraph summary + any blocking questions
+2. Leave the `plan-readme` topic on the repo until Adam approves; remove it once the PR merges.
+
+---
+
+**Definition of Done**
+- Every `plan-readme` repo has an up-to-date README that satisfies the checklist above.
+- A plan branch exists off `dev` with the documentation changes.
+- PR assigned to Adam + matching Eureka FARMS project item in "Ready".


### PR DESCRIPTION
## Summary
- replace cohort/plan/readme.md with the new plan-readme execution guide
- detail repo discovery, dev branch handling, README checklist, PR + project workflows

## Testing
- doc-only