### PR TITLE
chore: remove nyx user rename, use cheliped from base image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # ╭──────────────────────────────────────────────────────────╮
-# │ Nyx Calder - OpenClaw AI Assistant Container            │
+# │ eureka!FARMS - OpenClaw AI Assistant Container           │
 # ╰──────────────────────────────────────────────────────────╯
 
 ARG CONTAINER_VERSION=latest
@@ -13,25 +13,16 @@ FROM docker.io/gautada/openclaw:$CONTAINER_VERSION AS container
 # ┌──────────────────────────────────────────────────────────┐
 # │ Metadata                                                 │
 # └──────────────────────────────────────────────────────────┘
-LABEL org.opencontainers.image.title="nyxcalder"
+LABEL org.opencontainers.image.title="eurekafarms"
 LABEL org.opencontainers.image.description="Nyx Calder - Autonomous Cloud-Native Software Engineer running OpenClaw"
-LABEL org.opencontainers.image.url="https://github.com/gautada/nyxcalder"
-LABEL org.opencontainers.image.source="https://github.com/gautada/nyxcalder"
-LABEL org.opencontainers.image.documentation="https://github.com/gautada/nyxcalder/blob/main/README.md"
+LABEL org.opencontainers.image.url="https://github.com/gautada/eurekafarms"
+LABEL org.opencontainers.image.source="https://github.com/gautada/eurekafarms"
+LABEL org.opencontainers.image.documentation="https://github.com/gautada/eurekafarms/blob/main/README.md"
 
 # ┌──────────────────────────────────────────────────────────┐
 # │ Application User                                         │
 # └──────────────────────────────────────────────────────────┘
-# Rename base container user (cheliped) to nyx
-ARG OLD_USER=cheliped
-ARG USER=nyx
-
-RUN /usr/sbin/usermod -l "$USER" "$OLD_USER" \
- && /usr/sbin/usermod -d /home/$USER -m $USER \
- && /usr/sbin/groupmod -n $USER $OLD_USER \
- && /bin/echo "$USER:$USER" | /usr/sbin/chpasswd \
- && rm -rf /home/$OLD_USER \
- && apt-get update \
+RUN apt-get update \
  && apt-get install -y --no-install-recommends \
             gh shellcheck python3-pip pipx \
  && rm -rf /var/lib/apt/lists/* \
@@ -44,6 +35,6 @@ COPY openclaw-control.sh /usr/bin/openclaw
 # ┌──────────────────────────────────────────────────────────┐
 # │ Service Configuration                                    │
 # └──────────────────────────────────────────────────────────┘
-RUN rm -rf /home/$USER \
- && /bin/ln -fsv /mnt/volumes/data /home/$USER \
- && chown -R $USER:$USER /home/$USER
+RUN rm -rf /home/cheliped \
+ && /bin/ln -fsv /mnt/volumes/data /home/cheliped \
+ && chown -R cheliped:cheliped /home/cheliped


### PR DESCRIPTION
References #26

Removes the `usermod`/`groupmod`/`chpasswd` block that renamed `cheliped` → `nyx`. Updates all `/home/nyx` references to `/home/cheliped`. Updates image labels from `nyxcalder`/`gautada/nyxcalder` to `eurekafarms`/`gautada/eurekafarms`. Only `Containerfile` is modified; `workspace/` is untouched.