### PR TITLE
feat: add kubectl via Kubernetes apt repo

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -24,12 +24,26 @@ LABEL org.opencontainers.image.documentation="https://github.com/gautada/eurekaf
 # └──────────────────────────────────────────────────────────┘
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-            gh shellcheck python3-pip pipx \
+            gh shellcheck python3-pip pipx gnupg \
  && rm -rf /var/lib/apt/lists/* \
  && pipx install pre-commit \
  && curl -sSL \
     https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-arm64 \
     -o /usr/local/bin/hadolint && chmod +x /usr/local/bin/hadolint
+
+# ┌──────────────────────────────────────────────────────────┐
+# │ kubectl                                                  │
+# └──────────────────────────────────────────────────────────┘
+RUN mkdir -p /etc/apt/keyrings \
+ && curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key \
+    | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg \
+ && echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.32/deb/ /' \
+    > /etc/apt/sources.list.d/kubernetes.list \
+ && apt-get update \
+ && apt-get install --yes --no-install-recommends kubectl \
+ && apt-get purge --yes gnupg \
+ && apt-get autoremove --yes \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY openclaw-control.sh /usr/bin/openclaw
 # ┌──────────────────────────────────────────────────────────┐


### PR DESCRIPTION
## Summary

Installs `kubectl` in the eurekafarms container using the official Kubernetes apt repository (`pkgs.k8s.io`).

## Changes

- **`Containerfile`**: adds `gnupg` to existing package install (for GPG key dearmoring); adds new kubectl RUN block that sets up the Kubernetes stable/v1.32 apt repo, installs kubectl, purges gnupg, and cleans up

## AC Status

| Criterion | Status |
|---|---|
| [Develop] kubectl installed via OS package manager | ✅ Met |
| [Develop] Clean hadolint state | ✅ Met (hadolint passes, DL3008 suppressed per repo convention) |
| [Integrate] CI build succeeds with kubectl binary in image | ⏳ Needs build/run |
| [Run] kubectl returns valid version string in running container | ⏳ Needs build/run |
| [Stretch] kubectl alias or shell completion configured | ❌ Not implemented |

## Risk: Low
- Additive change only; no existing functionality modified
- gnupg is purged after use — does not persist in the final image

## CI: Pending

Closes #37