### PR TITLE
process/integrate: add Sync CI/CD Workflow step for cicd-* repo topics

### DIFF
--- a/process/integrate.md
+++ b/process/integrate.md
@@ -62,6 +62,31 @@ to `gautada`. For each such item:
     comment. Apply the `clarification` label. Set
     `assignee = gautada`. Skip to the next item.
 
+- **Sync CI/CD Workflow** — check the topics of the
+  item's repository.
+  - For each topic that begins with `cicd-`, extract
+    the suffix (e.g. topic `cicd-container` →
+    suffix `container`).
+  - Fetch the source file from the `gautada/cicd`
+    repository at the path
+    `templates/cicd/{suffix}.yaml`.
+  - Compare it byte-for-byte against the destination
+    file `.github/workflows/cicd.yaml` in the item's
+    repository on the **default branch** (`main`).
+  - If the files differ (or the destination does not
+    exist): copy the source file to
+    `.github/workflows/cicd.yaml` in the item's
+    repository, commit directly to the **feature
+    branch** that Nyx prepared, and note the change
+    in a comment on the item.
+  - If the files already match: no action needed.
+  - If the repository has no `cicd-*` topics: skip
+    this step entirely.
+  - If multiple `cicd-*` topics exist: apply each
+    one in turn, using the last suffix found as the
+    authoritative source for `cicd.yaml` (topics are
+    processed in alphabetical order).
+
 - **Create PR** — create a PR from `{branch}` →
   `dev` per the
   [merge standard](https://github.com/gautada/eurekafarms/blob/main/standards/merge.md).


### PR DESCRIPTION
## Summary

Adds a new **Sync CI/CD Workflow** step to the integrate process, inserted before the Create PR step.

### What it does

For each item being integrated, Dev now checks the associated repository's topics. If any topic matches the pattern `cicd-{suffix}`:

- Fetch `gautada/cicd:templates/cicd/{suffix}.yaml`
- Compare to the item repo's `.github/workflows/cicd.yaml` on the default branch
- If they differ (or destination is missing): copy the source into the feature branch and note the change in a comment
- If they already match: no action
- No `cicd-*` topics → step skipped entirely
- Multiple `cicd-*` topics → processed alphabetically, last one wins for `cicd.yaml`

This ensures repos always have the latest pipeline definition before the PR is created and the Action fires.

References the integrate process update discussed with Adam on 2026-03-04.