### PR TITLE
process/integrate: multiple cicd-* topics is a failure, not a merge

### DIFF
--- a/process/integrate.md
+++ b/process/integrate.md
@@ -82,10 +82,11 @@ to `gautada`. For each such item:
   - If the files already match: no action needed.
   - If the repository has no `cicd-*` topics: skip
     this step entirely.
-  - If multiple `cicd-*` topics exist: apply each
-    one in turn, using the last suffix found as the
-    authoritative source for `cicd.yaml` (topics are
-    processed in alphabetical order).
+  - If multiple `cicd-*` topics exist: this is a
+    configuration error. Post a comment documenting
+    which conflicting topics were found. Apply a
+    `failure` label. Set `assignee = gautada`. Skip
+    to the next item.
 
 - **Create PR** — create a PR from `{branch}` →
   `dev` per the


### PR DESCRIPTION
## Summary

Follow-up to #42. The original PR was merged before this fix landed.

### Change

When a repository has **more than one** `cicd-*` topic, the Sync CI/CD Workflow step should treat it as a configuration error — not silently pick one.

**Before:** last topic alphabetically wins for `cicd.yaml`
**After:** post a comment listing the conflicting topics, apply `failure` label, assign to `gautada`, skip to next item.

One `cicd.yaml` per repo — ambiguity is always a failure.