### PR TITLE
Add files:read requirement for Slack uploads

### DIFF
--- a/setup/slack.md
+++ b/setup/slack.md
@@ -27,10 +27,13 @@ Go to OAuth & Permissions → Bot Token Scopes, add:
 - `im:history`
 - `im:write`
 - `reactions:write`
+- `files:read` ← **required** so Slack includes the `files[]` payload on inbound messages
 - `files:write`
 
 Click Install to Workspace → copy the Bot User
 OAuth Token (xoxb-...).
+
+> **Note:** Slack will only include attached-file metadata in `message.*` events when the bot has `files:read`. Without it, uploads appear as plain text on the agent side even though Slack shows the file in the DM or channel.
 
 ### Step 4 — Subscribe to Events
 


### PR DESCRIPTION
## Summary\n- document that the Slack bot needs the `files:read` scope\n- clarify that uploads appear as plain text without it\n\n## Testing\n- [ ] Not run (doc-only change)\n