### PR TITLE
Update standards and process for pre-commit and AC stage tags (#29)

### DIFF
--- a/process/code.md
+++ b/process/code.md
@@ -76,17 +76,7 @@ you have previously commented on that carry a
     comment. This label is permanent and never
     removed. Continue to handoff regardless.
 
-- **Pre-commit lint** — before handing off, install
-  and run the pre-commit hooks by executing:
-
-  ```bash
-  curl -sSfL https://raw.githubusercontent.com/gautada/cicd/main/bin/pre-commit | bash
-  ```
-
-  This installs pre-commit and configures hooks that
-  block commits until all checks pass. Run the hooks
-  against all staged changes and resolve every
-  reported issue before committing.
+- **Pre-commit lint** — Before handing off, run `pre-commit run --all-files` (or the equivalent linting/static analysis tool configured for the repository) and fix any identified issues. All pre-commit checks must pass before proceeding.
   - If any lint issue **cannot** be resolved: post a
     comment describing the specific failure(s).
     Apply a `failure` label. Set
@@ -94,8 +84,6 @@ you have previously commented on that carry a
     Leave the working branch as-is so Adam can
     inspect it. Adam will remove the label and
     reassign when resolved.
-  - All pre-commit checks must pass before
-    proceeding.
 
 - **Hand off to Dev** — post a comment in the
   following format so the branch is clearly

--- a/standards/criteria.md
+++ b/standards/criteria.md
@@ -75,3 +75,13 @@ must be tagged with its pipeline stage:
 - [ ] [Run] Criterion three
 - [ ] (Stretch) [Run] Criterion four
 ```
+
+---
+
+## Stage Tags Reference
+
+| Tag | Stage | Owner | When verified |
+|---|---|---|---|
+| `[Develop]` | Development | Nyx | Before PR is opened |
+| `[Integrate]` | Integration | Dev | After merge to `dev`, CI passing |
+| `[Run]` | Runtime | Ren | In production / running instance |

--- a/standards/develop.md
+++ b/standards/develop.md
@@ -45,9 +45,7 @@ including:
 
 ## Acceptance Criteria Self-Review
 
-After completing code changes, Nyx must post a
-comment containing a markdown checklist of all
-acceptance criteria:
+After completing code changes, Nyx must run `pre-commit run --all-files` (or equivalent linting/static analysis tool configured for the repository) and fix any identified issues. Once passing, Nyx must post a comment containing a markdown checklist of all acceptance criteria:
 
 ```markdown
 ## AC Self-Review


### PR DESCRIPTION
Resolves #29. Updates standards/criteria.md, standards/develop.md, and process/code.md to reflect the new pre-commit requirements and AC stage tag standards.