### PR TITLE
docs: clarify stage tags and pre-commit requirements

### DIFF
--- a/process/code.md
+++ b/process/code.md
@@ -90,15 +90,13 @@ curl -sSfL https://raw.githubusercontent.com/gautada/cicd/main/bin/pre-commit | 
   markdown checklist of all acceptance criteria that you
   completed and achieved
 
-- **Pre-commit lint** — install
-  and run the pre-commit hooks by executing:
-
-  ```sh
-  curl -sSfL https://raw.githubusercontent.com/gautada/cicd/main/bin/pre-commit | bash
-  ```
-  attempt to correct all intining issues reported by the command
-  by efficiently editing the code.  Document all changes as new comments
-  to the issue
+- **Pre-commit lint** — Before handing off, run
+  `pre-commit run --all-files` (or the equivalent
+  linting/static-analysis tool configured for the
+  repository). Correct every issue raised by the
+  command and note any notable clean-ups in an issue
+  comment so later stages understand the adjustments
+  you made.
   
   - If any lint issue **cannot** be resolved: post a
     comment describing the specific failure(s).

--- a/standards/criteria.md
+++ b/standards/criteria.md
@@ -58,7 +58,7 @@ Avoid words like "should," "properly,"
 "gracefully," or "as expected" without defining
 what that means.
 
-### 6. Format as a markdown checklist with stage tags
+### 5. Format as a markdown checklist with stage tags
 
 Acceptance criteria must be posted as a single
 comment using a markdown checklist. Each criterion
@@ -75,3 +75,8 @@ must be tagged with its pipeline stage:
 - [ ] [Run] Criterion three
 - [ ] (Stretch) [Run] Criterion four
 ```
+
+Include the stage tag on **every** criterion, even
+stretch goals. The tag tells Nyx, Dev, and Ren when
+the work is validated. Copy/paste the template above
+into new issues so criteria stay consistent.

--- a/standards/develop.md
+++ b/standards/develop.md
@@ -100,6 +100,13 @@ unmet criterion. This label is permanent — it
 persists through the pipeline and is never removed.
 It does not block handoff.
 
+After the self-review comment is posted, run
+`pre-commit run --all-files` (or any additional
+repo-specific tooling) and fix every reported issue
+before handing off. If a tool failure cannot be
+resolved, document the failure details in the issue
+and stop work until Adam provides direction.
+
 ## Handoff Comment Format
 
 The handoff comment to Dev must follow this exact


### PR DESCRIPTION
## Summary
- require stage tags in the criteria standard and provide a ready-to-copy template
- document the An unexpected error has occurred: PermissionError: [Errno 13] Permission denied: '/root/.cache' requirement in both the standards and the code process
- keep the change minimal so Nyx knows exactly what to run before handoff

## Testing
- An unexpected error has occurred: PermissionError: [Errno 13] Permission denied: '/root/.cache' *(fails in this environment because npm cannot write to /root/.npm; see issue comment for details)*