### PR TITLE
docs: document slack @mention requirements

### DIFF
--- a/docs/slack-mentions.md
+++ b/docs/slack-mentions.md
@@ -1,0 +1,14 @@
+# Slack @Mention Requirements
+
+In multi-agent Slack channels (like `#2-development`), agents are configured with `ackReactionScope: "group-mentions"`.
+
+## Behavior
+- Agents will **only** respond or acknowledge messages that explicitly @mention them (e.g., `@nyxcalder`).
+- Messages without a specific @mention will be ignored by the agents to prevent noise in shared channels.
+
+## Best Practices
+- Always tag the specific agent you are addressing.
+- If you need a general response, pick the agent most relevant to the task (e.g., `@blairplan` for planning, `@nyxcalder` for development).
+
+## Configuration Note
+This behavior is controlled by the `ackReactionScope` setting in the OpenClaw channel configuration.


### PR DESCRIPTION
This PR adds documentation regarding the requirement to @mention agents in multi-agent Slack channels. This addresses the confusion where agents appear unresponsive when messaged without a tag.

Summary:
- Created `docs/slack-mentions.md` to explain `group-mentions` behavior and best practices.

AC Status:
- [x] [Develop] Documentation created.
- [ ] [Integrate] Merged to dev.

Risk: Low