### PR TITLE
Add dynamic timestamp to hb shortcut and update usage instructions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -14,11 +14,11 @@ name: "Continuous Integration: Build and Publish Multi-Architecture Container Im
 jobs:
   check:
     uses: gautada/cicd/.github/workflows/ci-linter.yaml@main
-  # deep-scan:
-    # needs: check
-    # uses: gautada/cicd/.github/workflows/ci-deep-scan.yaml@main
+  deep-scan:
+    needs: check
+    uses: gautada/cicd/.github/workflows/ci-deep-scan.yaml@main
   build-arm64:
-    # needs: check
+    needs: check
     uses: gautada/cicd/.github/workflows/ci-podman-build.yaml@main
     with:
       architecture: "arm64"
@@ -26,7 +26,7 @@ jobs:
       REGISTRY_USERNAME: ${{ secrets.DOCKERIO_REGISTRY }}
       REGISTRY_TOKEN: ${{ secrets.DOCKERIO_TOKEN }}
   build-amd64:
-    # needs: check
+    needs: check
     uses: gautada/cicd/.github/workflows/ci-podman-build.yaml@main
     with:
       architecture: "amd64"

--- a/docs/heartbeat-shortcut.md
+++ b/docs/heartbeat-shortcut.md
@@ -33,7 +33,8 @@ Espanso is a cross‑platform, open-source text expander. Once installed, typing
 
 1. In Slack (DM with Nyx or `#2-development`), type `;;hb` and hit **space**.  
 2. Espanso replaces it with the full heartbeat text automatically.  
-3. Add any extra context (current time, channel, etc.) **after** the expansion if needed, then send.
+3. **Important:** In shared channels, you must explicitly tag the agent (e.g., `@nyxcalder`) after the expansion so they process the message.  
+4. Send the message and wait for the agent’s acknowledgement.
 
 ### Verification
 

--- a/docs/shortcuts/espanso/heartbeat.yml
+++ b/docs/shortcuts/espanso/heartbeat.yml
@@ -1,7 +1,10 @@
 # Import this file into ~/.config/espanso/match/ to create the heartbeat snippet.
 matches:
   - trigger: ";;hb"
-    replace: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. Current time: {{current_time}}"
+    replace: |
+      Read HEARTBEAT.md if it exists (workspace context). Follow it strictly.
+      Do not infer or repeat old tasks from prior chats.
+      Current time: {{current_time}}
     propagate_case: false
     word: false
     vars:

--- a/docs/shortcuts/espanso/heartbeat.yml
+++ b/docs/shortcuts/espanso/heartbeat.yml
@@ -1,6 +1,11 @@
 # Import this file into ~/.config/espanso/match/ to create the heartbeat snippet.
 matches:
   - trigger: ";;hb"
-    replace: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats."
+    replace: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. Current time: {{current_time}}"
     propagate_case: false
     word: false
+    vars:
+      - name: "current_time"
+        type: "date"
+        params:
+          format: "%Y-%m-%d %H:%M:%S"

--- a/pre-commit
+++ b/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck shell=bash
 # =============================================================================
 # bin/pre-commit
 # Syncs pre-commit config from gautada/cicd and runs pre-commit --all-files.


### PR DESCRIPTION
PR #25 opened → dev
AC met:
- [x] [Develop] The heartbeat shortcut is implemented using a tool that avoids retyping the full prompt (Espanso with dynamic timestamp).
- [x] [Develop] The shortcut is documented in `docs/heartbeat-shortcut.md`.
- [x] [Develop] Verification steps updated with @mention requirement for shared channels.
- [x] [Develop] A fallback mechanism is documented.

AC pending (needs build/deploy):
- [ ] [Integrate] The documentation is merged into the main branch.
- [ ] [Run] The shortcut is usable by Adam in the main Slack channel.

Risk: low
CI: pending

Assigned to the integration stage.